### PR TITLE
Fixing inherited value-by-reference problem

### DIFF
--- a/lib/xdcc.js
+++ b/lib/xdcc.js
@@ -27,10 +27,9 @@ irc.Client.prototype.getXdcc = function(hostUser, hostCommand, path, isFile) {
   }
 
   var self = this;
-  
-  self.say(hostUser, hostCommand);
 
-  self.on('ctcp-privmsg', function(from, to, text) {
+  // only do this for the next private message
+  self.once('ctcp-privmsg', function(from, to, text) {
     if (to == self.nick && from == hostUser) {
       if (text.substr(0, 9) == 'DCC SEND ') {
         // making sure we DON'T overrule the parameters
@@ -72,6 +71,9 @@ irc.Client.prototype.getXdcc = function(hostUser, hostCommand, path, isFile) {
       }
     }
   });
+
+  // connect first, request afterwards
+  self.say(hostUser, hostCommand);
 
 };
 


### PR DESCRIPTION
When using configuration objects, giving a configuration path in the function leads to overruling the configuration value, leading to errors for the subsequent calls.
